### PR TITLE
feat: allow selection of multiple tags

### DIFF
--- a/src/Chains.tsx
+++ b/src/Chains.tsx
@@ -66,7 +66,7 @@ export const Chains = () => {
   const [open, setOpen] = useState(!!selectedChainName);
   const ref = useRef<HTMLDivElement>(null);
 
-  const [filterTag, setFilterTag] = useUrlState<ChainTag>('tag', ChainTag.All);
+  const [filterTags, setFilterTags] = useUrlState<ChainTag[]>('tags', [ChainTag.All]);
 
   const [query, setQuery] = useUrlState<string>('search', '');
   const [value, setValue] = useState(query);
@@ -78,11 +78,12 @@ export const Chains = () => {
 
   const filteredChains = chains
     .filter((chain) => {
-      if (filterTag === ChainTag.All) {
+      if (filterTags.length === 0 || filterTags.includes(ChainTag.All)) {
         return true;
       }
 
-      return getChainTags(chain).includes(filterTag);
+      const chainTags = getChainTags(chain);
+      return filterTags.some(tag => chainTags.includes(tag));
     })
     .filter((chain) => {
       return (
@@ -151,7 +152,7 @@ export const Chains = () => {
           </Flex>
           <Flex center="y" gap="10px">
             <Search value={value} onChange={handleSearchChange} />
-            <TagSelect value={filterTag} onChange={setFilterTag} />
+            <TagSelect value={filterTags} onChange={setFilterTags} />
           </Flex>
         </Header>
         <Space height="35px" />
@@ -165,7 +166,8 @@ export const Chains = () => {
             <Text color="#6f6f6f" size={20}>
               {isSearch ? 'Found ' : ''}
               {filteredChains.length}
-              {filterTag === ChainTag.All ? ' ' : ` ${tagToLabel[filterTag]} `}
+              {' '}
+              {filterTags.includes(ChainTag.All) ? ' ' : `${filterTags.map(tag => tagToLabel[tag]).join(', ')} `}
               {filteredChains.length === 1 ? 'chain' : 'chains'}
             </Text>
           )}

--- a/src/Chains.tsx
+++ b/src/Chains.tsx
@@ -68,6 +68,19 @@ export const Chains = () => {
 
   const [filterTags, setFilterTags] = useUrlState<ChainTag[]>('tags', [ChainTag.All]);
 
+  const handleTagChange = (newTags: ChainTag[]) => {
+    if (filterTags.includes(ChainTag.All) && newTags.length > 0) {
+      // If current selection is "All" and new tags are selected, replace "All" with new tags
+      setFilterTags(newTags.filter(tag => tag !== ChainTag.All));
+    } else if (newTags.includes(ChainTag.All)) {
+      // If "All" is selected, remove other tags
+      setFilterTags([ChainTag.All]);
+    } else {
+      // Otherwise, update with the new tags
+      setFilterTags(newTags);
+    }
+  };
+
   const [query, setQuery] = useUrlState<string>('search', '');
   const [value, setValue] = useState(query);
 
@@ -152,7 +165,7 @@ export const Chains = () => {
           </Flex>
           <Flex center="y" gap="10px">
             <Search value={value} onChange={handleSearchChange} />
-            <TagSelect value={filterTags} onChange={setFilterTags} />
+            <TagSelect value={filterTags} onChange={handleTagChange} />
           </Flex>
         </Header>
         <Space height="35px" />

--- a/src/Chains.tsx
+++ b/src/Chains.tsx
@@ -69,14 +69,20 @@ export const Chains = () => {
   const [filterTags, setFilterTags] = useUrlState<ChainTag[]>('tags', [ChainTag.All]);
 
   const handleTagChange = (newTags: ChainTag[]) => {
-    if (filterTags.includes(ChainTag.All) && newTags.length > 0) {
-      // If current selection is "All" and new tags are selected, replace "All" with new tags
+    // If current selection is "All" and no tags are selected, do nothing
+    if (filterTags.includes(ChainTag.All) && newTags.length === 0) {
+      return;
+    }
+    // Else If current selection is "All" and new tags are selected, replace "All" with new tags
+    else if (filterTags.includes(ChainTag.All) && newTags.length > 0) {
       setFilterTags(newTags.filter(tag => tag !== ChainTag.All));
-    } else if (newTags.includes(ChainTag.All)) {
-      // If "All" is selected, remove other tags
+    }
+    // Else If "All" is selected, remove other tags
+    else if (newTags.includes(ChainTag.All)) {
       setFilterTags([ChainTag.All]);
-    } else {
-      // Otherwise, update with the new tags
+    }
+    // Otherwise, update with the new tags
+    else {
       setFilterTags(newTags);
     }
   };

--- a/src/components/TagSelect.tsx
+++ b/src/components/TagSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import { Flex } from './Flex';
 import styled from '@emotion/styled';
@@ -6,53 +6,37 @@ import { ChainTag } from '../constants';
 import { Tag } from './Tag';
 
 export interface TagSelectProps {
-  value: ChainTag;
-  onChange: (value: ChainTag) => void;
+  value: ChainTag[];
+  onChange: (value: ChainTag[]) => void;
 }
 
 export const TagSelect: React.FC<TagSelectProps> = ({ value, onChange }) => {
-  const [tags, setTags] = useState(() => Object.values(ChainTag));
+  const tags = Object.values(ChainTag);
 
-  const currentIndex = tags.findIndex((tag) => tag === value);
-  const selectedTag = tags[currentIndex];
-
-  const handleSelect = (newIndex: number) => {
-    const newTag = tags[newIndex];
-
-    const newTags = [...tags];
-    newTags[newIndex] = tags[currentIndex];
-    newTags[currentIndex] = newTag;
-    setTags(newTags);
-
-    onChange(newTag);
+  const handleSelect = (tag: ChainTag) => {
+    const newValue = value.includes(tag)
+      ? value.filter(t => t !== tag)
+      : [...value, tag];
+    onChange(newValue);
   };
 
   return (
     <Wrapper gap="10px" as={motion.div} center="y">
-      <motion.div key={selectedTag} layoutId={selectedTag}>
-        <Tag tag={selectedTag} big />
-      </motion.div>
       <OptionsList gap="5px" wrap>
-        {tags.map((tag, index) => {
-          if (tag === selectedTag) {
-            return null;
-          }
-
-          return (
-            <motion.div
-              key={tag}
-              layoutId={tag}
-              transition={{
-                type: 'spring',
-                damping: 20,
-                stiffness: 300,
-              }}
-              onClick={() => handleSelect(index)}
-            >
-              <TagStyled tag={tag} />
-            </motion.div>
-          );
-        })}
+        {tags.map((tag) => (
+          <motion.div
+            key={tag}
+            layoutId={tag}
+            transition={{
+              type: 'spring',
+              damping: 20,
+              stiffness: 300,
+            }}
+            onClick={() => handleSelect(tag)}
+          >
+            <TagStyled tag={tag} big={value.includes(tag)} />
+          </motion.div>
+        ))}
       </OptionsList>
     </Wrapper>
   );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -39,8 +39,11 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   ethereum: {
     addedAt: 1710873111000,
   },
-  lukso: {
-    addedAt: 1720194661000,
+  flare: {
+    addedAt: 1724679974000,
+  },
+  cronos: {
+    addedAt: 1724679974000,
   },
   bsc: {
     addedAt: 1710873111000,
@@ -54,26 +57,47 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   fusemainnet: {
     addedAt: 1721210072000,
   },
-  mantapacific: {
-    addedAt: 1710873111000,
-  },
   fraxtal: {
     addedAt: 1718116503000,
   },
   kroma: {
     addedAt: 1722948900000,
   },
+  filecoin: {
+    addedAt: 1724679974000,
+  },
+  cronoszkevm: {
+    addedAt: 1724679974000,
+  },
+  astar: {
+    addedAt: 1723239227000,
+  },
   endurance: {
     addedAt: 1720717456000,
   },
-  lisk: {
-    addedAt: 1722948900000,
+  confluxespace: {
+    addedAt: 1724679974000,
+  },
+  coredao: {
+    addedAt: 1724679974000,
+  },
+  dogechain: {
+    addedAt: 1724679974000,
+  },
+  fractalconfluence: {
+    addedAt: 1724679974000,
+  },
+  kava: {
+    addedAt: 1724679974000,
   },
   inevm: {
     addedAt: 1710873111000,
   },
-  luksotestnet: {
-    addedAt: 1720194661000,
+  astarzkevm: {
+    addedAt: 1724679974000,
+  },
+  ham: {
+    addedAt: 1724679974000,
   },
   connextsepolia: {
     addedAt: 1720752748000,
@@ -84,8 +108,17 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   kinto: {
     addedAt: 1722948900000,
   },
+  b3: {
+    addedAt: 1724679974000,
+  },
   base: {
     addedAt: 1710873111000,
+  },
+  clique: {
+    addedAt: 1724679974000,
+  },
+  carbon: {
+    addedAt: 1724679974000,
   },
   chiado: {
     addedAt: 1710873111000,
@@ -102,8 +135,17 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   holesky: {
     addedAt: 1716189243000,
   },
+  funki: {
+    addedAt: 1724679974000,
+  },
+  alephzero: {
+    addedAt: 1724679974000,
+  },
   arbitrum: {
     addedAt: 1710873111000,
+  },
+  arbitrumnova: {
+    addedAt: 1724679974000,
   },
   celo: {
     addedAt: 1710873111000,
@@ -132,6 +174,12 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   basesepolia: {
     addedAt: 1719341681000,
   },
+  ebi: {
+    addedAt: 1724679974000,
+  },
+  bitlayer: {
+    addedAt: 1724679974000,
+  },
   cheesechain: {
     addedAt: 1722416578000,
   },
@@ -144,8 +192,11 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   galadrieldevnet: {
     addedAt: 1723220538000,
   },
-  fhenix: {
-    addedAt: 1721845016000,
+  forma: {
+    addedAt: 1723836705000,
+  },
+  fhenixtestnet: {
+    addedAt: 1724088664000,
   },
   eclipsetestnet: {
     addedAt: 1710873111000,
@@ -165,16 +216,43 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   optimism: {
     addedAt: 1710873111000,
   },
+  rootstock: {
+    addedAt: 1724167734000,
+  },
+  rootstocktestnet: {
+    addedAt: 1723823685000,
+  },
+  lukso: {
+    addedAt: 1720194661000,
+  },
   viction: {
     addedAt: 1710873111000,
   },
+  shibarium: {
+    addedAt: 1724679974000,
+  },
   polygon: {
+    addedAt: 1710873111000,
+  },
+  mantapacific: {
     addedAt: 1710873111000,
   },
   mint: {
     addedAt: 1722948900000,
   },
   xlayer: {
+    addedAt: 1722416578000,
+  },
+  orderly: {
+    addedAt: 1724679974000,
+  },
+  molten: {
+    addedAt: 1724668186000,
+  },
+  pulsechain: {
+    addedAt: 1724679974000,
+  },
+  worldchain: {
     addedAt: 1722416578000,
   },
   redstone: {
@@ -186,11 +264,17 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   polygonzkevm: {
     addedAt: 1710873111000,
   },
+  lisk: {
+    addedAt: 1722948900000,
+  },
   moonbeam: {
     addedAt: 1710873111000,
   },
   sei: {
     addedAt: 1718116503000,
+  },
+  tenet: {
+    addedAt: 1724679974000,
   },
   mintsepoliatest: {
     addedAt: 1720717400000,
@@ -198,11 +282,17 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   sanko: {
     addedAt: 1722948900000,
   },
+  ronin: {
+    addedAt: 1724679974000,
+  },
   tangletestnet: {
     addedAt: 1722948900000,
   },
   merlin: {
     addedAt: 1722948900000,
+  },
+  luksotestnet: {
+    addedAt: 1720194661000,
   },
   mantle: {
     addedAt: 1719932096000,
@@ -219,11 +309,11 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   neutron: {
     addedAt: 1710873111000,
   },
-  worldchain: {
-    addedAt: 1722416578000,
-  },
   zetachain: {
     addedAt: 1716224404000,
+  },
+  polynomial: {
+    addedAt: 1724679974000,
   },
   zircuit: {
     addedAt: 1722948900000,
@@ -234,29 +324,20 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   polygonamoy: {
     addedAt: 1722948900000,
   },
+  proteustestnet: {
+    addedAt: 1710873111000,
+  },
   superpositiontestnet: {
     addedAt: 1721048842000,
   },
   real: {
     addedAt: 1722948900000,
   },
-  scrollsepolia: {
-    addedAt: 1710873111000,
-  },
-  sketchpad: {
-    addedAt: 1716583202000,
-  },
-  optimismsepolia: {
-    addedAt: 1723543214000,
-  },
-  osmosis: {
-    addedAt: 1718120223000,
-  },
-  proteustestnet: {
-    addedAt: 1710873111000,
-  },
   taiko: {
     addedAt: 1719932096000,
+  },
+  scrollsepolia: {
+    addedAt: 1710873111000,
   },
   scroll: {
     addedAt: 1710873111000,
@@ -264,19 +345,37 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   xai: {
     addedAt: 1722948900000,
   },
+  sketchpad: {
+    addedAt: 1716583202000,
+  },
+  saakuru: {
+    addedAt: 1724679974000,
+  },
   zoramainnet: {
     addedAt: 1721210072000,
   },
   sepolia: {
     addedAt: 1710873111000,
   },
+  optimismsepolia: {
+    addedAt: 1723543214000,
+  },
   plumetestnet: {
     addedAt: 1710873111000,
   },
-  solana: {
+  solanatestnet: {
     addedAt: 1710873111000,
   },
-  solanatestnet: {
+  ngmi: {
+    addedAt: 1724679974000,
+  },
+  osmosis: {
+    addedAt: 1718120223000,
+  },
+  rari: {
+    addedAt: 1724679974000,
+  },
+  solana: {
     addedAt: 1710873111000,
   },
   solanadevnet: {
@@ -284,5 +383,8 @@ export const extraChainData: ChainMap<ExtraChainData> = {
   },
   stride: {
     addedAt: 1717038016000,
+  },
+  stridetestnet: {
+    addedAt: 1723821623000,
   },
 };

--- a/src/hooks/useUrlState.ts
+++ b/src/hooks/useUrlState.ts
@@ -1,20 +1,28 @@
 import { useSearchParams } from './useSearchParams';
 
-export const useUrlState = <T extends string | number | boolean>(
+export const useUrlState = <T extends string | number | boolean | (string | number | boolean)[]>(
   key: string,
   initial: T,
 ) => {
   const [params, setParams] = useSearchParams({
-    [key]: initial,
+    [key]: Array.isArray(initial) ? initial.join(',') : initial,
   });
 
   const setValue = (value: T, triggerUpdate = true) => {
-    if (value === initial) {
+    if (JSON.stringify(value) === JSON.stringify(initial)) {
       setParams({ [key]: undefined }, triggerUpdate);
     } else {
-      setParams({ [key]: value }, triggerUpdate);
+      setParams({ [key]: Array.isArray(value) ? value.join(',') : value }, triggerUpdate);
     }
   };
 
-  return [params[key] as T, setValue] as const;
+  const getValue = (): T => {
+    const param = params[key];
+    if (Array.isArray(initial) && typeof param === 'string') {
+      return param.split(',').filter(Boolean) as T;
+    }
+    return param as T;
+  };
+
+  return [getValue(), setValue] as const;
 };


### PR DESCRIPTION
- allows a user to select multiple tags at a time (additively)
- selecting the "all" tag resets the tag filter
- selecting 0 tags falls back to "all"
	- if "all" is already selected, unselecting does nothing
- drive-by update to `extraChainData`