### PR TITLE
feat: filter out EVM chains without addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.13.0",
     "@hyperlane-xyz/registry": "^2.5.0",
     "@hyperlane-xyz/sdk": "^5.0.0",
+    "@hyperlane-xyz/utils": "^5.0.0",
     "@radix-ui/react-scroll-area": "^1.1.0",
     "@vercel/analytics": "^1.3.1",
     "auto-zustand-selectors-hook": "^2.0.5",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 import { ChainMap } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import { ExtraChainData } from '../types';
 
 export enum ChainTag {
@@ -10,12 +11,6 @@ export enum ChainTag {
   EVM = 'EVM',
   Solana = 'Solana',
   Cosmos = 'Cosmos',
-}
-
-export enum ProtocolType {
-  Ethereum = 'ethereum',
-  Sealevel = 'sealevel',
-  Cosmos = 'cosmos',
 }
 
 export const protocolToTag: Record<ProtocolType, ChainTag> = {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,6 +4,7 @@ import type {
   ChainMetadata,
   WarpCoreConfig,
 } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import { createSelectorFunctions } from 'auto-zustand-selectors-hook';
 import { create } from 'zustand';
 
@@ -40,9 +41,14 @@ export const useStore = createSelectorFunctions(
         registry.getAddresses(),
         Promise.resolve(warpRouteConfigs), // registry.getWarpRoutes(),
       ]);
-      const chains = Object.values(metadata).sort(
-        (a, b) => Number(a.chainId) - Number(b.chainId),
-      );
+      const chains = Object.values(metadata)
+        // Filter out EVM chains that don't have a mailbox address
+        .filter((chain) =>
+          chain.protocol === ProtocolType.Ethereum
+            ? addresses[chain.name]?.mailbox
+            : true
+        )
+        .sort((a, b) => Number(a.chainId) - Number(b.chainId));
 
       // const newExtraChainData: ChainMap<ExtraChainData> = {};
 


### PR DESCRIPTION
- feat: filter out EVM chains without addresses
- drive-by: get `ProtocolType` from utils package explicitly (which SDK should already be importing)

note: only doing for EVM chains because we don't have addresses in registry yet for non-evm chains